### PR TITLE
Fixed typo in product-thumbnail.js

### DIFF
--- a/blocks/product/product-thumbnail.js
+++ b/blocks/product/product-thumbnail.js
@@ -57,7 +57,7 @@ const ProductThumbnail = ({ thumbnails = [], activeVariant }) => {
           srcsetSizes={[400, 800, 1000]}
           sizes="(min-width: 1200px) 33vw, (min-width: 768px) 50vw, 100vw"
           width={1200}
-          className="is-defualt"
+          className="is-default"
         />
 
         {photos?.hover && (


### PR DESCRIPTION
Classname property was written as `is-defualt`. I changed it to `is-default`. Btw I checked the repo for other misspellings of default, but looks this is the only place it's wrong :)