### PR TITLE
Fixed ThemeSwitch somethimes displaying the wrong value

### DIFF
--- a/modules/shared/theme-switch.js
+++ b/modules/shared/theme-switch.js
@@ -12,15 +12,17 @@ const themes = [
 
 const ThemeSwitch = () => {
   const hasMounted = useHasMounted()
-  const { theme, setTheme } = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
 
   // Make sure it's client-only
   if (!hasMounted || !theme) return null
 
-  // store our current and next theme objects (will be first theme, if undefined)
+  // Store our current and next theme objects.
+  // Will match System Preference theme if supported,
+  // or resolve to the first theme if undefined 
   const currentIndex = Math.max(
     0,
-    themes.findIndex((t) => t.name === theme)
+    themes.findIndex((t) => t.name === resolvedTheme)
   )
 
   const nextTheme = themes[(currentIndex + 1) % themes.length]


### PR DESCRIPTION
If prefers-color-scheme is supported is on the user's computer, ThemeProvider would make that the active theme. 
However, ThemeSwitcher did not account for this, leading it to sometimes displaying the wrong value before the user selected a theme.

Another way to fix this would be to set `enableSystem={false}` on ThemeProvider. This will disable system preference detection.

For more info, see [https://www.npmjs.com/package/next-themes#themeprovider](https://www.npmjs.com/package/next-themes#themeprovider)